### PR TITLE
document.documentElement.clientHeight problem when search bar/bottom bar appears on devices

### DIFF
--- a/js/mobileSelect.js
+++ b/js/mobileSelect.js
@@ -588,7 +588,7 @@
 					if(_this.offsetSum == 0){
 						//offsetSum为0,相当于点击事件
 						// 0 1 [2] 3 4
-						var clickOffetNum = parseInt((document.documentElement.clientHeight - _this.moveEndY)/40);
+						var clickOffetNum = parseInt((window.innerHeight - _this.moveEndY)/40);
 						if(clickOffetNum!=2){
 							var offset = clickOffetNum - 2;
 							var newDistance = _this.curDistance[index] + (offset*_this.liHeight);
@@ -656,7 +656,7 @@
 					_this.oversizeBorder = -(theSlider.getElementsByTagName('li').length-3)*_this.liHeight;
 
 					if(_this.offsetSum == 0){
-						var clickOffetNum = parseInt((document.documentElement.clientHeight - _this.moveEndY)/40);
+						var clickOffetNum = parseInt((document.window.innerHeight - _this.moveEndY)/40);
 						if(clickOffetNum!=2){
 							var offset = clickOffetNum - 2;
 							var newDistance = _this.curDistance[index] + (offset*_this.liHeight);


### PR DESCRIPTION
Due to document.documentElement.clientHeight when on iphone/adroind appears the bottom bar or the searchbar the height is calculated incorrectly so the selector doesn't work as intended to and skips elements. That's why window.innerHeight helps keeping track of the window height and makes it possible to select even if the bar appears or dissapears